### PR TITLE
Change visibility of FakeHttpContext properties

### DIFF
--- a/src/FakeHttpContext/FakeHttpContext.cs
+++ b/src/FakeHttpContext/FakeHttpContext.cs
@@ -10,9 +10,9 @@ namespace FakeHttpContext
 {
     public class FakeHttpContext : SwitcherContainer
     {
-        private readonly HttpContext _conextBackup;
-        private readonly FakeWorkerRequest _fakeWorkerRequest = new FakeWorkerRequest();
-        private readonly FakeHostEnvironment _fakeHostEnvironment = new FakeHostEnvironment();
+        protected readonly HttpContext _conextBackup;
+        protected readonly FakeWorkerRequest _fakeWorkerRequest = new FakeWorkerRequest();
+        protected readonly FakeHostEnvironment _fakeHostEnvironment = new FakeHostEnvironment();
 
         public FakeHttpContext()
         {


### PR DESCRIPTION
Its very hard now to create derived implementation that would make use of original FakeHttpContext, can we expose those properties?